### PR TITLE
feat: expose array-to-connections

### DIFF
--- a/array-to-connection.js
+++ b/array-to-connection.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./lib/array-to-connection');


### PR DESCRIPTION
Provide default implementation for array-to-connections. If user's pagination setup matches default approach taken in `swagql`, a local copy of `array-to-connections.js` can simply export `swagql/array-to-connections.js`. If the pagination implementation differs, users can write their own mapping. 