### PR TITLE
--name-prefix flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Build a GraphQL schema from a given Swagger or Open API specification.
 
 ```bash
-cat swagger.yml | swagql [-p <babel-plugin1-path>,<babel-plugin2-path>] > schema.js
+cat swagger.yml | swagql [-p <babel-plugin1-path>,<babel-plugin2-path>] [-n NamePrefix_]> schema.js
 ```
 
 Input swagger schema can be in YAML or JSON format. The generated schema exports
@@ -17,6 +17,11 @@ the authorization status for given request and swagger auth config. If a given
 request does not satisfy the required auth status, you can throw an auth error
 from this function. `requestContext` can be used to hold the information about
 the current request, such as the request object itself.
+
+In the case where you are merging multiple schemas, you may wish to have all
+of the methods and types be unique, and can pass the `--name-prefix` (or `-n`)
+flag to prepend the given string to all of the above.
+
 ```js
 const { schema, FETCH, VERIFY_AUTH_STATUS } = require(pathToSchema);
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -40,6 +40,7 @@ const { version } = require('../package.json');
 program
   .version(version)
   .option('-p, --plugins <type>', 'List of babel plugins', p => p.split(','))
+  .option('-n, --name-prefix <str>', 'Prefix to prepend onto ops & types')
   .parse(process.argv);
 
 function main(isCli) {
@@ -55,7 +56,11 @@ function main(isCli) {
   process.stdin.on('end', async () => {
     try {
       const swaggerSpec = await YAML.safeLoad(inputData);
-      const schema = await generateSchema(swaggerSpec, program.plugins);
+      const schema = await generateSchema(
+        swaggerSpec,
+        program.plugins,
+        program.namePrefix
+      );
       process.stdout.write(schema.code.trim());
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/lib/generate-schema.js
+++ b/lib/generate-schema.js
@@ -36,10 +36,10 @@ const babel = require('babel-core');
 
 const SwagQL = require('./generator/swagql');
 
-async function generateSchema(swaggerSpec, plugins) {
+async function generateSchema(swaggerSpec, plugins, namePrefix) {
   // SwagQL.fromSwagger() returns a SwagQL instance
   // where ast is a method that performs the transformation
-  const { ast } = await SwagQL.fromSwagger(swaggerSpec);
+  const { ast } = await SwagQL.fromSwagger(swaggerSpec, null, namePrefix);
   return babel.transformFromAst(ast, null, {
     plugins: plugins,
     generatorOpts: {

--- a/lib/generator/deoperationalize.js
+++ b/lib/generator/deoperationalize.js
@@ -170,7 +170,8 @@ function deoperationalize(
   outputTypes,
   connections,
   defaultSecurity,
-  securityDefinitions
+  securityDefinitions,
+  namePrefix = ''
 ) {
   const id = op.operationId;
   const normalizedId = normalizeOperationId(id);
@@ -337,14 +338,14 @@ function deoperationalize(
   }
 
   const operationNode = t.objectProperty(
-    t.identifier(normalizedId),
+    t.identifier(namePrefix + normalizedId),
     t.objectExpression([
       t.objectProperty(t.identifier('type'), resolvedType),
       t.objectProperty(t.identifier('args'), t.objectExpression(args)),
       resolveMethod,
     ])
   );
-  operationNode['operation'] = op;
+  Object.defineProperty(operationNode, 'operation', { value: op });
   return operationNode;
 }
 module.exports = deoperationalize;

--- a/lib/generator/swagql.js
+++ b/lib/generator/swagql.js
@@ -41,7 +41,7 @@ const Connectionator = require('./connectionator');
 const deoperationalize = require('./deoperationalize');
 const TypeMap = require('./type-map');
 
-const DEFAULT_OPTIONS = {
+const DEFAULT_PARSE_OPTIONS = {
   resolve: {
     external: false,
   },
@@ -95,14 +95,15 @@ function* getOperations(api) {
 }
 
 class SwagQL {
-  constructor(api) {
+  constructor(api, namePrefix) {
     this.api = api;
+    this.namePrefix = namePrefix;
     this.queryFields = new Map();
     this.mutationFields = new Map();
     this.builtins = new BuiltInTypes();
 
-    this.outputTypes = new TypeMap(this.builtins, false);
-    this.inputTypes = new TypeMap(this.builtins, true);
+    this.outputTypes = new TypeMap(this.builtins, false, namePrefix);
+    this.inputTypes = new TypeMap(this.builtins, true, namePrefix);
 
     if (api.definitions) {
       for (const [apiName, apiType] of Object.entries(api.definitions)) {
@@ -133,10 +134,11 @@ class SwagQL {
       this.outputTypes,
       this.connections,
       this.api.security,
-      this.api.securityDefinitions
+      this.api.securityDefinitions,
+      this.namePrefix
     );
 
-    fields.set(id, operationNode);
+    fields.set(operationNode.key.name, operationNode);
   }
 
   get ast() {
@@ -172,11 +174,15 @@ class SwagQL {
     return program;
   }
 
-  static async fromSwagger(spec, parseOptions = DEFAULT_OPTIONS) {
+  static async fromSwagger(spec, parseOptions, namePrefix) {
     // results in a swagger object without any $ref pointers
-    const api = await SwaggerParser.dereference(spec, parseOptions, undefined);
+    const api = await SwaggerParser.dereference(
+      spec,
+      parseOptions || DEFAULT_PARSE_OPTIONS,
+      undefined
+    );
 
-    return new SwagQL(api);
+    return new SwagQL(api, namePrefix);
   }
 }
 module.exports = SwagQL;

--- a/lib/generator/type-map.js
+++ b/lib/generator/type-map.js
@@ -146,12 +146,12 @@ function byRefOrder(t1, t2) {
 }
 
 class Type {
-  constructor(typeMap, apiType, apiName) {
+  constructor(typeMap, apiType, apiName, namePrefix = '') {
     this.typeMap = typeMap;
     this.apiName = apiName;
     this.apiType = apiType;
     this.graphqlName = typeMap.registerUniqueTypeName(
-      `${normalizeTypeName(apiName)}${typeMap.postfix}`
+      `${namePrefix}${normalizeTypeName(apiName)}${typeMap.postfix}`
     );
     this.ast = null;
     this.refOrder = null;
@@ -173,9 +173,10 @@ class Type {
 }
 
 class TypeMap {
-  constructor(builtInTypes, isInput = false) {
+  constructor(builtInTypes, isInput = false, namePrefix = '') {
     this.builtInTypes = builtInTypes;
     this.isInput = isInput;
+    this.namePrefix = namePrefix;
 
     this.bySwaggerName = new Map();
     this.bySwaggerDefinition = new Map();
@@ -255,12 +256,12 @@ class TypeMap {
   }
 
   addSwaggerDefinition(apiType, apiName) {
-    this.add(new Type(this, apiType, apiName));
+    this.add(new Type(this, apiType, apiName, this.namePrefix));
   }
 
   createImplicitType(apiName, apiType) {
     if (!this.bySwaggerName.has(apiName)) {
-      const type = new Type(this, apiType, apiName);
+      const type = new Type(this, apiType, apiName, this.namePrefix);
       this.add(type);
     }
     return this.getBySwaggerName(apiName);

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const path = require('path');
+const { promisify } = require('util');
+const execAsync = promisify(require('child_process').exec);
+
+const assert = require('assertive');
+
+const cliPath = path.join(__dirname, '..', 'cli.js');
+const petstorePath = path.join(__dirname, 'fixtures', 'petstore.json');
+
+describe('cli', () => {
+  it('accepts --name-prefix', async () => {
+    const { stdout: js } = await execAsync(
+      `${cliPath} --name-prefix=FOO_ < ${petstorePath}`
+    );
+    assert.include('FOO_petById:', js);
+    assert.include("name: 'FOO_Pet'", js);
+  });
+});


### PR DESCRIPTION
To reduce the need to use `graphql-tools` to rename the methods, build
the ability to prefix names into swagql.  I will include an example of running on petstore in the comments.