### PR TITLE
handle invalid key names

### DIFF
--- a/lib/generator/deoperationalize.js
+++ b/lib/generator/deoperationalize.js
@@ -94,11 +94,24 @@ async function resolve(parent, options, context, info) {
 
   const mapFields = MAP_FIELDS;
 
+  function getValue(object, keys) {
+    return keys.split('.').reduce(function (o, k) {
+      return (o || {})[k];
+    }, object);
+  }
+
   if (mapFields && mapFields.length) {
-    mapFields.forEach( ({name, originalName, paramType}) => {
-      const value = options[paramType][name];
-      options[paramType][originalName] = value;
-      delete options[paramType][name];
+    mapFields.reverse().forEach(({
+      name,
+      originalName,
+      path
+    }) => {
+      let obj = getValue(options, path);
+      if (obj) {
+        const value = obj[name];
+        obj[originalName] = value;
+        delete obj[name];
+      }   
     });
   }
 
@@ -287,24 +300,36 @@ function deoperationalize(
 
   if (isBody) {
     params.forEach(param => {
-      const properties = get(param, 'schema.properties', []);
-      const usedNames = new Set(Object.keys(properties));
-      for (const originalName of Object.keys(properties)) {
-        if (!isValidName(originalName)) {
-          const name = makeUniqueValidName(originalName, usedNames);
-          mapFields.push(
-            t.objectExpression([
-              t.objectProperty(t.identifier('name'), t.stringLiteral(name)),
-              t.objectProperty(
-                t.identifier('originalName'),
-                t.stringLiteral(originalName)
-              ),
-              t.objectProperty(
-                t.identifier('paramType'),
-                t.stringLiteral(param.in)
-              ),
-            ])
-          );
+      if (param.in === 'body') {
+        const properties = get(param, 'schema.properties', []);
+        buildMapFields(properties, param.name);
+      }
+    });
+  }
+
+  function buildMapFields(obj, objPath) {
+    const usedNames = new Set(Object.keys(obj));
+    Object.keys(obj).forEach(key => {
+      let pathName = key;
+      if (!isValidName(key)) {
+        const name = makeUniqueValidName(key, usedNames);
+        pathName = name;
+        mapFields.push(
+          t.objectExpression([
+            t.objectProperty(t.identifier('name'), t.stringLiteral(name)),
+            t.objectProperty(
+              t.identifier('originalName'),
+              t.stringLiteral(key)
+            ),
+            t.objectProperty(t.identifier('path'), t.stringLiteral(objPath)),
+          ])
+        );
+      }
+      if (typeof obj[key] === 'object') {
+        const properties = get(obj[key], 'properties', false);
+        if (properties) {
+          const childPath = `${objPath}.${pathName}`;
+          buildMapFields(properties, childPath);
         }
       }
     });

--- a/lib/generator/deoperationalize.js
+++ b/lib/generator/deoperationalize.js
@@ -38,6 +38,9 @@ const camelCase = require('lodash/camelCase');
 
 const parser = require('@babel/parser');
 const pick = require('lodash').pick;
+const get = require('lodash/get');
+const includes = require('lodash/includes');
+const { isValidName, makeUniqueValidName } = require('./valid-name');
 
 function normalizeOperationId(operationId) {
   return camelCase(operationId).replace(/^get(.)/, (m, nextChar) =>
@@ -72,6 +75,31 @@ async function resolve(parent, options, context, info) {
   if (context[VERIFY_AUTH_STATUS]) {
     const securityConfig = SECURITY_CONFIG;
     context[VERIFY_AUTH_STATUS](securityConfig);
+  }
+
+  const data = await ${RESOLVE_FETCH};
+  return {
+    rawResponseBody: data,
+    rawInputOptions: options
+  };
+}`);
+
+const buildMapFieldsResolveFunction = template(`\
+async function resolve(parent, options, context, info) {
+
+  if (context[VERIFY_AUTH_STATUS]) {
+    const securityConfig = SECURITY_CONFIG;
+    context[VERIFY_AUTH_STATUS](securityConfig);
+  }
+
+  const mapFields = MAP_FIELDS;
+
+  if (mapFields && mapFields.length) {
+    mapFields.forEach( ({name, originalName, paramType}) => {
+      const value = options[paramType][name];
+      options[paramType][originalName] = value;
+      delete options[paramType][name];
+    });
   }
 
   const data = await ${RESOLVE_FETCH};
@@ -254,6 +282,34 @@ function deoperationalize(
     );
   });
 
+  const isBody = includes(['POST', 'PUT'], httpMethod);
+  const mapFields = [];
+
+  if (isBody) {
+    params.forEach(param => {
+      const properties = get(param, 'schema.properties', []);
+      const usedNames = new Set(Object.keys(properties));
+      for (const originalName of Object.keys(properties)) {
+        if (!isValidName(originalName)) {
+          const name = makeUniqueValidName(originalName, usedNames);
+          mapFields.push(
+            t.objectExpression([
+              t.objectProperty(t.identifier('name'), t.stringLiteral(name)),
+              t.objectProperty(
+                t.identifier('originalName'),
+                t.stringLiteral(originalName)
+              ),
+              t.objectProperty(
+                t.identifier('paramType'),
+                t.stringLiteral(param.in)
+              ),
+            ])
+          );
+        }
+      }
+    });
+  }
+
   const isEmptyResponse = !returnType;
   let resolvedType = outputTypes.ref(
     isEmptyResponse ? createEmptyResponseType() : returnType,
@@ -277,12 +333,19 @@ function deoperationalize(
       ? t.objectExpression(pathParams)
       : t.identifier('undefined'),
     BODY_OPTION: bodyParam || t.identifier('undefined'),
+    MAP_FIELDS: mapFields.length
+      ? t.arrayExpression(mapFields)
+      : t.identifier('undefined'),
     ROOT_PROPERTY: t.identifier(rootPropertyName),
     BODY_READER: isEmptyResponse ? t.identifier('text') : t.identifier('json'),
     SECURITY_CONFIG: securityConfig,
   };
 
-  if (isEmptyResponse) {
+  if (isBody && mapFields.length) {
+    resolveMethod = toObjectMethod(
+      buildMapFieldsResolveFunction(resolveOptions)
+    );
+  } else if (isEmptyResponse) {
     resolveMethod = toObjectMethod(
       buildEmptyResponseResolveFunction(resolveOptions)
     );

--- a/lib/generator/type-map.js
+++ b/lib/generator/type-map.js
@@ -35,8 +35,7 @@
 const t = require('babel-types');
 const camelCase = require('lodash/camelCase');
 const upperFirst = require('lodash/upperFirst');
-
-const validName = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
+const { isValidName, makeUniqueValidName } = require('./valid-name');
 
 function normalizeTypeName(typeName) {
   return upperFirst(camelCase(typeName));
@@ -131,7 +130,7 @@ function generateTypeAST(typeMap, type) {
   ]);
 
   function generateFieldAST(propKey) {
-    const isValidName = validName.test(propKey);
+    const isValid = isValidName(propKey);
     const properties = [];
     properties.push(
       t.objectProperty(
@@ -144,7 +143,7 @@ function generateTypeAST(typeMap, type) {
         )
       )
     );
-    if (!isValidName && !isInput) {
+    if (!isValid && !isInput) {
       properties.push(
         t.objectProperty(
           t.identifier('resolve'),
@@ -159,20 +158,8 @@ function generateTypeAST(typeMap, type) {
         )
       );
     }
-    const name = isValidName ? propKey : makeValidName(propKey);
+    const name = isValid ? propKey : makeUniqueValidName(propKey, usedNames);
     return t.objectProperty(t.identifier(name), t.objectExpression(properties));
-  }
-
-  function makeValidName(originalName) {
-    const newName = camelCase(originalName).replace(/^(?=\d)/, '_');
-    let uniqIdx = 2;
-    let finalName = newName;
-    while (usedNames.has(finalName)) {
-      finalName = `${newName}${uniqIdx++}`;
-    }
-    usedNames.delete(originalName);
-    usedNames.add(finalName);
-    return finalName;
   }
 
   return node;

--- a/lib/generator/type-map.js
+++ b/lib/generator/type-map.js
@@ -98,9 +98,7 @@ function generateTypeAST(typeMap, type) {
   const usedNames = new Set(Object.keys(props));
 
   const fields = Object.keys(props).map(propKey => {
-    return validName.test(propKey)
-      ? generateFieldAST(propKey)
-      : generateValidFieldAST(propKey);
+    return generateFieldAST(propKey);
   });
 
   if (!fields.length) {
@@ -133,41 +131,21 @@ function generateTypeAST(typeMap, type) {
   ]);
 
   function generateFieldAST(propKey) {
-    return t.objectProperty(
-      t.identifier(propKey),
-      t.objectExpression([
-        t.objectProperty(
-          t.identifier('type'),
-          typeMap.ref(
-            props[propKey],
-            requiredProps.includes(propKey),
-            type,
-            propKey
-          )
-        ),
-      ])
+    const isValidName = validName.test(propKey);
+    const properties = [];
+    properties.push(
+      t.objectProperty(
+        t.identifier('type'),
+        typeMap.ref(
+          props[propKey],
+          requiredProps.includes(propKey),
+          type,
+          propKey
+        )
+      )
     );
-  }
-
-  function generateValidFieldAST(propKey) {
-    if (!isInput) {
-      return generateValidFieldWithResolverAST(propKey);
-    }
-    const newName = makeValidName(propKey);
-    return t.objectProperty(
-      t.identifier(newName),
-      t.objectExpression([
-        t.objectProperty(t.identifier('type'), typeMap.ref({ type: 'string' })),
-      ])
-    );
-  }
-
-  function generateValidFieldWithResolverAST(propKey) {
-    const newName = makeValidName(propKey);
-    return t.objectProperty(
-      t.identifier(newName),
-      t.objectExpression([
-        t.objectProperty(t.identifier('type'), typeMap.ref({ type: 'string' })),
+    if (!isValidName && !isInput) {
+      properties.push(
         t.objectProperty(
           t.identifier('resolve'),
           t.arrowFunctionExpression(
@@ -178,9 +156,11 @@ function generateTypeAST(typeMap, type) {
               true
             )
           )
-        ),
-      ])
-    );
+        )
+      );
+    }
+    const name = isValidName ? propKey : makeValidName(propKey);
+    return t.objectProperty(t.identifier(name), t.objectExpression(properties));
   }
 
   function makeValidName(originalName) {

--- a/lib/generator/type-map.js
+++ b/lib/generator/type-map.js
@@ -83,6 +83,7 @@ function generateScalarFallbackAST(typeMap, type) {
 
 function generateTypeAST(typeMap, type) {
   const { graphqlName, apiType } = type;
+  const { isInput } = typeMap;
 
   if (apiType.type === 'array') return generateListAST(typeMap, type);
 
@@ -99,7 +100,7 @@ function generateTypeAST(typeMap, type) {
   const fields = Object.keys(props).map(propKey => {
     return validName.test(propKey)
       ? generateFieldAST(propKey)
-      : generateValidFieldWithResolverAST(propKey);
+      : generateValidFieldAST(propKey);
   });
 
   if (!fields.length) {
@@ -144,6 +145,19 @@ function generateTypeAST(typeMap, type) {
             propKey
           )
         ),
+      ])
+    );
+  }
+
+  function generateValidFieldAST(propKey) {
+    if (!isInput) {
+      return generateValidFieldWithResolverAST(propKey);
+    }
+    const newName = makeValidName(propKey);
+    return t.objectProperty(
+      t.identifier(newName),
+      t.objectExpression([
+        t.objectProperty(t.identifier('type'), typeMap.ref({ type: 'string' })),
       ])
     );
   }

--- a/lib/generator/type-map.js
+++ b/lib/generator/type-map.js
@@ -34,8 +34,6 @@
 
 const t = require('babel-types');
 const camelCase = require('lodash/camelCase');
-const findIndex = require('lodash/findIndex');
-const includes = require('lodash/includes');
 const upperFirst = require('lodash/upperFirst');
 
 const validName = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
@@ -96,7 +94,7 @@ function generateTypeAST(typeMap, type) {
   }
 
   const requiredProps = apiType.required || [];
-  const usedNames = Object.keys(props);
+  const usedNames = new Set(Object.keys(props));
 
   const fields = Object.keys(props).map(propKey => {
     return validName.test(propKey)
@@ -172,18 +170,14 @@ function generateTypeAST(typeMap, type) {
   }
 
   function makeValidName(originalName) {
-    const newName = /^[0-9]/.test(originalName)
-      ? `_${originalName}`
-      : camelCase(originalName);
+    const newName = camelCase(originalName).replace(/^(?=\d)/, '_');
     let uniqIdx = 2;
     let finalName = newName;
-    while (includes(usedNames, finalName)) {
+    while (usedNames.has(finalName)) {
       finalName = `${newName}${uniqIdx++}`;
     }
-    const idx = findIndex(usedNames, k => {
-      return k === originalName;
-    });
-    usedNames[idx] = finalName;
+    usedNames.delete(originalName);
+    usedNames.add(finalName);
     return finalName;
   }
 

--- a/lib/generator/type-map.js
+++ b/lib/generator/type-map.js
@@ -34,7 +34,11 @@
 
 const t = require('babel-types');
 const camelCase = require('lodash/camelCase');
+const findIndex = require('lodash/findIndex');
+const includes = require('lodash/includes');
 const upperFirst = require('lodash/upperFirst');
+
+const validName = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
 
 function normalizeTypeName(typeName) {
   return upperFirst(camelCase(typeName));
@@ -92,23 +96,14 @@ function generateTypeAST(typeMap, type) {
   }
 
   const requiredProps = apiType.required || [];
+  const usedNames = Object.keys(props);
 
   const fields = Object.keys(props).map(propKey => {
-    return t.objectProperty(
-      t.identifier(propKey),
-      t.objectExpression([
-        t.objectProperty(
-          t.identifier('type'),
-          typeMap.ref(
-            props[propKey],
-            requiredProps.includes(propKey),
-            type,
-            propKey
-          )
-        ),
-      ])
-    );
+    return validName.test(propKey)
+      ? generateFieldAST(propKey)
+      : generateValidFieldWithResolverAST(propKey);
   });
+
   if (!fields.length) {
     fields.push(
       t.objectProperty(
@@ -137,6 +132,60 @@ function generateTypeAST(typeMap, type) {
       ])
     ),
   ]);
+
+  function generateFieldAST(propKey) {
+    return t.objectProperty(
+      t.identifier(propKey),
+      t.objectExpression([
+        t.objectProperty(
+          t.identifier('type'),
+          typeMap.ref(
+            props[propKey],
+            requiredProps.includes(propKey),
+            type,
+            propKey
+          )
+        ),
+      ])
+    );
+  }
+
+  function generateValidFieldWithResolverAST(propKey) {
+    const newName = makeValidName(propKey);
+    return t.objectProperty(
+      t.identifier(newName),
+      t.objectExpression([
+        t.objectProperty(t.identifier('type'), typeMap.ref({ type: 'string' })),
+        t.objectProperty(
+          t.identifier('resolve'),
+          t.arrowFunctionExpression(
+            [t.identifier('obj')],
+            t.memberExpression(
+              t.identifier('obj'),
+              t.stringLiteral(propKey),
+              true
+            )
+          )
+        ),
+      ])
+    );
+  }
+
+  function makeValidName(originalName) {
+    const newName = /^[0-9]/.test(originalName)
+      ? `_${originalName}`
+      : camelCase(originalName);
+    let uniqIdx = 2;
+    let finalName = newName;
+    while (includes(usedNames, finalName)) {
+      finalName = `${newName}${uniqIdx++}`;
+    }
+    const idx = findIndex(usedNames, k => {
+      return k === originalName;
+    });
+    usedNames[idx] = finalName;
+    return finalName;
+  }
 
   return node;
 }

--- a/lib/generator/valid-name.js
+++ b/lib/generator/valid-name.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+const camelCase = require('lodash/camelCase');
+
+function isValidName(name) {
+  const validName = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
+  return validName.test(name);
+}
+
+function makeValidName(name) {
+  return camelCase(name).replace(/^(?=\d)/, '_');
+}
+
+function makeUniqueValidName(name, usedNames) {
+  const newName = makeValidName(name);
+  let uniqIdx = 2;
+  let finalName = newName;
+  while (usedNames.has(finalName)) {
+    finalName = `${newName}${uniqIdx++}`;
+  }
+  usedNames.delete(name);
+  usedNames.add(finalName);
+  return finalName;
+}
+
+module.exports = {
+  isValidName,
+  makeValidName,
+  makeUniqueValidName,
+};

--- a/test/fixtures/petstore.json
+++ b/test/fixtures/petstore.json
@@ -995,6 +995,24 @@
         "5 Things are Neato!": {
           "type": "string"
         },
+        "safe": {
+          "type": "object",
+          "properties": {
+            "alsoSafe": {
+              "type": "object",
+              "properties": {
+                "Totally Not Safe!": {
+                  "type": "object",
+                  "properties": {
+                    "4": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "photoUrls": {
           "type": "array",
           "xml": {

--- a/test/fixtures/petstore.json
+++ b/test/fixtures/petstore.json
@@ -986,8 +986,11 @@
           "type": "string",
           "example": "doggie"
         },
-        "nick-name": {
-          "type": "string"
+        "is-nick-name": {
+          "type": "boolean"
+        },
+        "age-in-dog-years": {
+          "type": "integer"
         },
         "5 Things are Neato!": {
           "type": "string"

--- a/test/fixtures/petstore.json
+++ b/test/fixtures/petstore.json
@@ -986,6 +986,12 @@
           "type": "string",
           "example": "doggie"
         },
+        "nick-name": {
+          "type": "string"
+        },
+        "5 Things are Neato!": {
+          "type": "string"
+        },
         "photoUrls": {
           "type": "array",
           "xml": {

--- a/test/generator/swagql.test.js
+++ b/test/generator/swagql.test.js
@@ -12,8 +12,7 @@ const http = require('http');
 const generateSchema = require('../../lib/generate-schema');
 
 describe('SwagQL', () => {
-  const port = 4000;
-  let server;
+  let server, port;
 
   before(async () => {
     server = http.createServer((req, res) => {
@@ -22,13 +21,18 @@ describe('SwagQL', () => {
           JSON.stringify({
             id: 1,
             name: 'MaxTheDog',
-            'nick-name': 'Honey Bear',
-            '5 Things are Neato!': 'It worked!',
+            'is-nick-name': true,
+            'age-in-dog-years': 49,
+            '5 Things are Neato!': 'It works!',
           })
         );
       }
     });
-    await server.listen(port);
+    port = await new Promise(resolve => {
+      server.listen(0, () => {
+        resolve(server.address().port);
+      });
+    });
   });
 
   after(() => server.close());
@@ -90,7 +94,8 @@ describe('SwagQL', () => {
           petById(petId: $petId) {
             id
             name
-            nickName
+            isNickName
+            ageInDogYears
             _5ThingsAreNeato
           }
         }
@@ -112,7 +117,10 @@ describe('SwagQL', () => {
     assert.equal(1, result.data.petById.id);
 
     assert.notEqual(null, result.data.myPlaces);
-    assert.equal('Honey Bear', result.data.petById.nickName);
-    assert.equal('It worked!', result.data.petById._5ThingsAreNeato);
+
+    assert.equal(true, result.data.petById.isNickName);
+    assert.equal(49, result.data.petById.ageInDogYears);
+    // eslint-disable-next-line no-underscore-dangle
+    assert.equal('It works!', result.data.petById._5ThingsAreNeato);
   });
 });

--- a/test/generator/swagql.test.js
+++ b/test/generator/swagql.test.js
@@ -168,10 +168,16 @@ describe('SwagQL', () => {
           photoUrls: '/photo.png',
           ageInDogYears: 5,
           isNickName: false,
+          safe: {
+            alsoSafe: {
+              totallyNotSafe: {
+                _4: 'nested objects work!',
+              },
+            },
+          },
         },
       }
     );
-    assert.notEqual(null, mutation);
     assert.equal('Fido', mutation.data.addPet.rawInputOptions.body.name);
     assert.equal(
       5,
@@ -180,6 +186,12 @@ describe('SwagQL', () => {
     assert.equal(
       false,
       mutation.data.addPet.rawInputOptions.body['is-nick-name']
+    );
+    assert.equal(
+      'nested objects work!',
+      mutation.data.addPet.rawInputOptions.body.safe.alsoSafe[
+        'Totally Not Safe!'
+      ]['4']
     );
   });
 });

--- a/test/generator/swagql.test.js
+++ b/test/generator/swagql.test.js
@@ -24,6 +24,11 @@ describe('SwagQL', () => {
             'is-nick-name': true,
             'age-in-dog-years': 49,
             '5 Things are Neato!': 'It works!',
+            safe: {
+              alsoSafe: {
+                'Totally Not Safe!': { '4': 'Nested objects work too!' },
+              },
+            },
           })
         );
       }
@@ -97,6 +102,13 @@ describe('SwagQL', () => {
             isNickName
             ageInDogYears
             _5ThingsAreNeato
+            safe {
+              alsoSafe {
+                totallyNotSafe {
+                  _4
+                }
+              }
+            }
           }
         }
       `,
@@ -122,5 +134,10 @@ describe('SwagQL', () => {
     assert.equal(49, result.data.petById.ageInDogYears);
     // eslint-disable-next-line no-underscore-dangle
     assert.equal('It works!', result.data.petById._5ThingsAreNeato);
+    assert.equal(
+      'Nested objects work too!',
+      // eslint-disable-next-line no-underscore-dangle
+      result.data.petById.safe.alsoSafe.totallyNotSafe._4
+    );
   });
 });

--- a/test/generator/swagql.test.js
+++ b/test/generator/swagql.test.js
@@ -12,14 +12,23 @@ const http = require('http');
 const generateSchema = require('../../lib/generate-schema');
 
 describe('SwagQL', () => {
+  const port = 4000;
   let server;
+
   before(async () => {
     server = http.createServer((req, res) => {
       if (req.url === '/v2/pet/1') {
-        res.end(JSON.stringify({ id: 1, name: 'MaxTheDog' }));
+        res.end(
+          JSON.stringify({
+            id: 1,
+            name: 'MaxTheDog',
+            'nick-name': 'Honey Bear',
+            '5 Things are Neato!': 'It worked!',
+          })
+        );
       }
     });
-    await server.listen(8080);
+    await server.listen(port);
   });
 
   after(() => server.close());
@@ -79,15 +88,17 @@ describe('SwagQL', () => {
       `
         query MyQuery($petId: Int!) {
           petById(petId: $petId) {
-            name
             id
+            name
+            nickName
+            _5ThingsAreNeato
           }
         }
       `,
       null,
       {
         [gqlSchemaModule.exports.FETCH](urlPath, options) {
-          return fetch(`http://localhost:8080/v2${urlPath}`, options);
+          return fetch(`http://localhost:${port}/v2${urlPath}`, options);
         },
         [gqlSchemaModule.exports.VERIFY_AUTH_STATUS]() {},
       },
@@ -101,5 +112,7 @@ describe('SwagQL', () => {
     assert.equal(1, result.data.petById.id);
 
     assert.notEqual(null, result.data.myPlaces);
+    assert.equal('Honey Bear', result.data.petById.nickName);
+    assert.equal('It worked!', result.data.petById._5ThingsAreNeato);
   });
 });

--- a/test/generator/type-map.test.js
+++ b/test/generator/type-map.test.js
@@ -28,6 +28,16 @@ const EMPTY_OBJ = {
   type: 'object',
 };
 
+const BAD_NAMES_OBJ = {
+  type: 'object',
+  properties: {
+    1: { type: 'number' },
+    'bad-name': { type: 'string' },
+    'Bad?Name': { type: 'string' },
+    'Bad Name': { type: 'string' },
+  },
+};
+
 describe('TypeMap', () => {
   it('can manage type defintions', () => {
     const builtIn = new BuiltInTypes();
@@ -137,6 +147,38 @@ const Recursive = new GraphQLObjectType({
     return value;
   }
 
+});`,
+      generate(t.program(typeMap.astNodes), { quotes: 'single' }).code
+    );
+  });
+
+  it('handles objects with invalid property key names', () => {
+    const builtIn = new BuiltInTypes();
+    const typeMap = new TypeMap(builtIn);
+    typeMap.addSwaggerDefinition(BAD_NAMES_OBJ, 'BadNames');
+    t.assertIdentifier(typeMap.ref(BAD_NAMES_OBJ), { name: 'BadNames' });
+
+    assert.equal(
+      `const BadNames = new GraphQLObjectType({
+  name: 'BadNames',
+  fields: () => ({
+    _1: {
+      type: GraphQLString,
+      resolve: obj => obj['1']
+    },
+    badName: {
+      type: GraphQLString,
+      resolve: obj => obj['bad-name']
+    },
+    badName2: {
+      type: GraphQLString,
+      resolve: obj => obj['Bad?Name']
+    },
+    badName3: {
+      type: GraphQLString,
+      resolve: obj => obj['Bad Name']
+    }
+  })
 });`,
       generate(t.program(typeMap.astNodes), { quotes: 'single' }).code
     );

--- a/test/generator/type-map.test.js
+++ b/test/generator/type-map.test.js
@@ -40,7 +40,7 @@ const BAD_NAMES_OBJ = {
 };
 
 describe('TypeMap', () => {
-  it('can manage type defintions', () => {
+  it('can manage type definitions', () => {
     const builtIn = new BuiltInTypes();
     const typeMap = new TypeMap(builtIn);
     typeMap.addSwaggerDefinition(SIMPLE_OBJ, 'My.Type/#bar');

--- a/test/generator/type-map.test.js
+++ b/test/generator/type-map.test.js
@@ -32,7 +32,7 @@ const BAD_NAMES_OBJ = {
   type: 'object',
   properties: {
     1: { type: 'number' },
-    'bad-name': { type: 'string' },
+    'bad-name': { type: 'boolean' },
     'Bad?Name': { type: 'string' },
     'Bad Name': { type: 'string' },
     '5 Things are Neato!': { type: 'string' },
@@ -164,11 +164,11 @@ const Recursive = new GraphQLObjectType({
   name: 'BadNames',
   fields: () => ({
     _1: {
-      type: GraphQLString,
+      type: GraphQLFloat,
       resolve: obj => obj['1']
     },
     badName: {
-      type: GraphQLString,
+      type: GraphQLBoolean,
       resolve: obj => obj['bad-name']
     },
     badName2: {

--- a/test/generator/type-map.test.js
+++ b/test/generator/type-map.test.js
@@ -35,6 +35,7 @@ const BAD_NAMES_OBJ = {
     'bad-name': { type: 'string' },
     'Bad?Name': { type: 'string' },
     'Bad Name': { type: 'string' },
+    '5 Things are Neato!': { type: 'string' },
   },
 };
 
@@ -152,7 +153,7 @@ const Recursive = new GraphQLObjectType({
     );
   });
 
-  it('handles objects with invalid property key names', () => {
+  it('handles objects with invalid property names', () => {
     const builtIn = new BuiltInTypes();
     const typeMap = new TypeMap(builtIn);
     typeMap.addSwaggerDefinition(BAD_NAMES_OBJ, 'BadNames');
@@ -177,6 +178,10 @@ const Recursive = new GraphQLObjectType({
     badName3: {
       type: GraphQLString,
       resolve: obj => obj['Bad Name']
+    },
+    _5ThingsAreNeato: {
+      type: GraphQLString,
+      resolve: obj => obj['5 Things are Neato!']
     }
   })
 });`,


### PR DESCRIPTION
1. Check for invalid key names, such as hyphens, special characters, names that begin with integers, etc.
2. Provide a valid name and map to the original name via a resolve function.

This solves the validation error problem when running graphiql UI, for instance:
"Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"1\" does not."
"Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"Send-Id\" does not."

Here is an example of the generated field name for a key that has an invalid hyphen:
```javascript
fields: () => ({
    sendId: {
      type: GraphQLString,
      resolve: obj => obj['Send-Id']
    }
  })
```
Here is an example for a key named with an integer:
```javascript
fields: () => ({
    _1: {
      type: GraphQLInt,
      resolve: obj => obj['1']
    }
})
```
Further reading and a good example is at: https://graphql.org/graphql-js/type/#examples
```javascript
var AddressType = new GraphQLObjectType({
  name: 'Address',
  fields: {
    street: { type: GraphQLString },
    number: { type: GraphQLInt },
    formatted: {
      type: GraphQLString,
      resolve(obj) {
        return obj.number + ' ' + obj.street
      }
    }
  }
});
```
To handle mutations (post and put requests), the generator updates the resolver method to handle special character fields. In the following example, three fields are updated to the original source name before being posted back to the server:
 ```javascript
updatePet: {
      type: UpdatePetResponse,
      args: {
        body: {
          type: GraphQLNonNull(PetInput)
        },
        debug: {
          type: GraphQLString
        }
      },

      async resolve(parent, options, context, info) {
        if (context[VERIFY_AUTH_STATUS]) {
          const securityConfig = {
            "security": [{
              "petstore_auth": ["write:pets", "read:pets"]
            }],
            "definitions": {
              "petstore_auth": {
                "type": "oauth2",
                "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
                "flow": "implicit",
                "scopes": {
                  "write:pets": "modify pets in your account",
                  "read:pets": "read your pets"
                }
              }
            }
          };
          context[VERIFY_AUTH_STATUS](securityConfig);
        }

        const mapFields = [{
          name: 'isNickName',
          originalName: 'is-nick-name',
          paramType: 'body'
        }, {
          name: 'ageInDogYears',
          originalName: 'age-in-dog-years',
          paramType: 'body'
        }, {
          name: '_5ThingsAreNeato',
          originalName: '5 Things are Neato!',
          paramType: 'body'
        }];

        if (mapFields && mapFields.length) {
          mapFields.forEach(({
            name,
            originalName,
            paramType
          }) => {
            const value = options[paramType][name];
            options[paramType][originalName] = value;
            delete options[paramType][name];
          });
        }

        const data = await context[FETCH]('/pet', {
          method: 'PUT',
          endpointName: 'updatePet',
          qs: {
            'debug': options.debug
          },
          pathParams: undefined,
          headers: undefined,
          json: options.body
        }).text();
        return {
          rawResponseBody: data,
          rawInputOptions: options
        };
      }

    }
```