### PR TITLE
don't die on Query or Mutation without fields

### DIFF
--- a/lib/generator/swagql.js
+++ b/lib/generator/swagql.js
@@ -61,14 +61,16 @@ const FETCH = Symbol(GRAPHQL_FETCH_SYMBOL_NAME);
 const VERIFY_AUTH_STATUS = Symbol(GRAPHQL_VERIFY_AUTH_STATUS_SYMBOL_NAME)`);
 
 const buildPostfix = template(`\
-const Query = new GraphQLObjectType({
+const queryFields = QUERY_FIELDS;
+const Query = queryFields && new GraphQLObjectType({
   name: 'Query',
-  fields: QUERY_FIELDS,
+  fields: queryFields,
 });
 
-const Mutation = new GraphQLObjectType({
+const mutationFields = MUTATION_FIELDS;
+const Mutation = mutationFields && new GraphQLObjectType({
   name: 'Mutation',
-  fields: MUTATION_FIELDS,
+  fields: mutationFields,
 });
 
 module.exports = {
@@ -166,10 +168,12 @@ class SwagQL {
       ),
     });
     const postfix = buildPostfix({
-      QUERY_FIELDS: t.objectExpression(Array.from(this.queryFields.values())),
-      MUTATION_FIELDS: t.objectExpression(
-        Array.from(this.mutationFields.values())
-      ),
+      QUERY_FIELDS: this.queryFields.size
+        ? t.objectExpression(Array.from(this.queryFields.values()))
+        : t.nullLiteral(),
+      MUTATION_FIELDS: this.mutationFields.size
+        ? t.objectExpression(Array.from(this.mutationFields.values()))
+        : t.nullLiteral(),
     });
     const body = [
       t.expressionStatement(t.stringLiteral('use strict')),

--- a/test/generator/swagql.test.js
+++ b/test/generator/swagql.test.js
@@ -63,12 +63,9 @@ describe('SwagQL', () => {
         .find(
           n =>
             n.type === 'VariableDeclaration' &&
-            n.declarations[0].id.name === 'Mutation'
+            n.declarations[0].id.name === 'mutationFields'
         )
-        .declarations[0].init.arguments[0].properties.find(
-          p => p.key.name === 'fields'
-        )
-        .value.properties.find(p => p.key.name === 'updatePet')
+        .declarations[0].init.properties.find(p => p.key.name === 'updatePet')
         .value.properties.find(p => p.key.name === 'args')
         .value.properties.find(p => p.key.name === 'debug')
     );


### PR DESCRIPTION
apolloclient is fine if they're null, but not if their fields are empty


---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.3)_